### PR TITLE
Redirect url when trailing shlash is missing

### DIFF
--- a/docs/scripts/redirect.js
+++ b/docs/scripts/redirect.js
@@ -1,0 +1,12 @@
+function checkAndAddSlash() {
+    var currentUrl = window.location.href;
+
+    if (currentUrl.endsWith("/")) {
+        return;
+    }
+
+    var newUrl = currentUrl + "/";
+    window.location.href = newUrl;
+}
+
+checkAndAddSlash();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,8 @@ copyright: Copyright &copy; 2024 <a href="https://rzlsoftware.at">RZL Software G
 extra_css:
   - stylesheets/extra.css
   - stylesheets/pdf.css
+extra_javascript:
+  - scripts/redirect.js
           
 plugins:
   - search


### PR DESCRIPTION
Fix zu: https://az-devops.rzlsoftware.at/RZL/RZL/_sprints/taskboard/RZLCore%20-%20Core/RZL/Plan/Sprint/Core/Spring%20241?workitem=162546