### PR TITLE
Ausdruck Abrechnungen ergänzt um nicht in englischer Sprache möglich

### DIFF
--- a/docs/LOHN/Ausdrucke allgemein/Ausdruck Abrechnungen.md
+++ b/docs/LOHN/Ausdrucke allgemein/Ausdruck Abrechnungen.md
@@ -62,3 +62,6 @@ Wenn das Modul [*Kollektivverträge*](../Kollektivverträge/Abrechnungsbildschir
 Wenn abweichende externe Dienstnehmer-Nummern verwendet werden, können diese Nummern durch Aktivierung der Option *externe DN-Nr. drucken* auf der Abrechnung angedruckt werden.
 
 Wenn das Zusatzblatt zur Berechnung des Kontrollsechstels ausgedruckt werden soll, aktivieren Sie das Feld *K/6 Aufrollungen drucken*.
+
+!!! warning "Hinweis"
+    Die Abrechnung kann **nicht** in englischer Sprache ausgegeben werden.


### PR DESCRIPTION
Im Bereich Ausdruck allgemein - Ausdruck Abrechnung wurde ergänzt, dass die Abrechnung nicht in englischer Sprache ausgegeben werden kann.