### PR TITLE
chore(deps): pin MkDocs stack to 1.x

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -6,5 +6,4 @@ git config --local pull.rebase true
 
 pip install --upgrade pip
 
-pip install mkdocs
-pip install mkdocs-material mkdocs-awesome-pages-plugin mkdocs-minify-plugin mkdocs-enumerate-headings-plugin
+pip install -r requirements.txt

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,13 +9,25 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      devcontainers:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      pip:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -10,6 +10,7 @@ on:
       - docs/**
       - overrides/**
       - mkdocs.yml
+      - requirements.txt
     
   pull_request:
     types: [opened, synchronize, reopened, closed]
@@ -20,6 +21,7 @@ on:
       - docs/**
       - overrides/**
       - mkdocs.yml
+      - requirements.txt
 
 permissions:
   contents: read
@@ -34,7 +36,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install MkDocs
-        run: pip3 install mkdocs-material mkdocs-awesome-pages-plugin mkdocs-minify-plugin
+        run: pip3 install -r requirements.txt
 
       - name: Build Docs
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+mkdocs>=1.6,<2
+mkdocs-material>=9.7.5,<10
+mkdocs-awesome-pages-plugin>=2.9,<3
+mkdocs-minify-plugin>=0.8,<1
+mkdocs-enumerate-headings-plugin>=0.6,<1


### PR DESCRIPTION
## Summary

Pins the docs toolchain to MkDocs 1.x / Material 9.x so CI and DevContainers cannot pull MkDocs 2.0, which is incompatible with Material, plugins, and our theme overrides.

- Add `requirements.txt` with upper bounds (`mkdocs<2`, `mkdocs-material>=9.7.5,<10`, plugins pinned)
- Install from that file in CI and `.devcontainer/setup.sh`
- Enable Dependabot for pip and group updates by ecosystem (actions, devcontainers, pip)

## Why

MkDocs 2.0 removes the plugin system, rewrites theming, and has no migration path for Material projects. Until we choose a long-term path (stay on 1.x or move to Zensical), builds must stay on the 1.x stack.

## Test plan

- [ ] CI build on this PR succeeds (`mkdocs build --strict`)
- [ ] Confirm installed packages resolve within the pinned ranges
- [ ] DevContainer `postCreate` still installs from `requirements.txt`